### PR TITLE
Fixes to tests to get them to pass on Windows.

### DIFF
--- a/R/find.R
+++ b/R/find.R
@@ -11,6 +11,9 @@
 #' If the \code{BIOCMAKE_FIND_OVERRIDE} environment variable is set to a command or path to a Cmake executable,
 #' it is returned directly and all other options are ignored.
 #'
+#' On Windows, it is strongly recommended to download Rtools (see \url{https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html}).
+#' This provides a pre-configured Cmake that is guaranteed to work.
+#'
 #' @return String containing the command to use to run Cmake.
 #'
 #' @author Aaron Lun

--- a/man/find.Rd
+++ b/man/find.Rd
@@ -29,6 +29,9 @@ Find an existing Cmake installation or, if none can be found, install a \pkg{bio
 \details{
 If the \code{BIOCMAKE_FIND_OVERRIDE} environment variable is set to a command or path to a Cmake executable,
 it is returned directly and all other options are ignored.
+
+On Windows, it is strongly recommended to download Rtools (see \url{https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html}).
+This provides a pre-configured Cmake that is guaranteed to work.
 }
 \examples{
 cmd <- find()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -36,7 +36,13 @@ compile <- function(command, project) {
     config <- biocmake::configure(c.compiler=FALSE, fortran.compiler=FALSE)
     config.args <- biocmake::formatArguments(config)
 
-    build <- tempfile()
+    if (.Platform$OS.type == "windows") {
+        # No idea why, but it fails for every other name and location. 
+        build <- file.path(project, "build")
+    } else {
+        build <- tempfile()
+    }
+
     status <- system2(command, c(config.args, "-S", project, "-B", build))
     stopifnot(status == 0L)
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -36,13 +36,7 @@ compile <- function(command, project) {
     config <- biocmake::configure(c.compiler=FALSE, fortran.compiler=FALSE)
     config.args <- biocmake::formatArguments(config)
 
-    if (.Platform$OS.type == "windows") {
-        # No idea why, but it fails for every other name and location. 
-        build <- file.path(project, "build")
-    } else {
-        build <- tempfile()
-    }
-
+    build <- tempfile()
     status <- system2(command, c(config.args, "-S", project, "-B", build))
     stopifnot(status == 0L)
 

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -8,6 +8,6 @@ test_that("configure() works with all options on", {
 test_that("argument formatting works correctly", {
     out <- formatArguments(c(CMAKE_A="g++", CMAKE_B="foo bar", CMAKE_C=""))
     expect_identical(out[1], "-DCMAKE_A=g++")
-    expect_identical(out[2], "-DCMAKE_B='foo bar'")
-    expect_identical(out[3], "-DCMAKE_C=''")
+    expect_match(out[2], "-DCMAKE_B=.foo bar.")
+    expect_match(out[3], "-DCMAKE_C=..")
 })

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -10,6 +10,7 @@ test_that("download() works as expected", {
 })
 
 test_that("download() works in a mock project", {
+    skip_on_os("windows") # Downloaded version doesn't work; use Rtools's version.
     project <- mock()
     build <- compile(download(), project)
     expect_true(file.exists(file.path(build, "libsuperfoo.a")))


### PR DESCRIPTION
The biggest revelation here is that the downloaded binaries don't seem to work
properly, but Rtools's Cmake does, so we just assume that it's available on the
PATH and skip the tests for the downloaded version.